### PR TITLE
Fix markdown extensions usage

### DIFF
--- a/pygiftparser/utils.py
+++ b/pygiftparser/utils.py
@@ -86,7 +86,7 @@ def htmlRendering(src):
 
 
 def markdownRendering(src):
-    return markdown.markdown(transformSpecials(src), MARKDOWN_EXT)
+    return markdown.markdown(transformSpecials(src), extensions=MARKDOWN_EXT)
 
 
 def markupRendering(src, markup='html'):


### PR DESCRIPTION
markdown function signature has changed in recent version

This prevents the following errors:
`TypeError: markdown() takes 1 positional argument but 2 were given`